### PR TITLE
Added the need for YOUR_HOME parameter in .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.4'
 
 services:
 
@@ -53,9 +53,10 @@ services:
       volumes_from:
         - applications
       volumes:
-        - ~/.aws:/home/laradock/.aws
-        - ~/.composer/auth.json:/home/laradock/.composer/auth.json
-        - ~/.nemo/.bash_history:/home/laradock/.bash_history
+        - $YOUR_HOME/.aws/:/home/laradock/.aws/
+        - type: bind
+          source: $YOUR_HOME/.composer/auth.json
+          target: /home/laradock/.composer/auth.json
       extra_hosts:
         - "dockerhost:${DOCKER_HOST_IP}"
       ports:

--- a/nemo.env
+++ b/nemo.env
@@ -325,3 +325,4 @@ PHP_IDE_CONFIG=serverName=laradock
 
 COMPOSE_CONVERT_WINDOWS_PATHS=1
 
+YOUR_HOME=/home/xxxx


### PR DESCRIPTION
Fixed the docker-compose volumes issue
volumes short notation only links to folders - changed to long notation and using bind
to use long notation file format bumped to 2.4
~ is no longer supported, so added an env variable (YOUR_HOME)